### PR TITLE
Better git commands to improve prompt performance for large repos

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -31,12 +31,15 @@ else
     RESET="\033[m"
 fi
 
+# NOTE: This is really slow when the repo is huge
 function parse_git_dirty() {
     [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working directory clean" ]] && echo "*"
 }
 
+# FIXME: Removing asterisk when dirty for better performance on large repos
 function parse_git_status() {
-    git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
+    # git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
+    git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1/"
 }
 
 function bashprompt() {
@@ -46,7 +49,7 @@ function bashprompt() {
     else
         username=""
     fi
-    git_status=`git status 2> /dev/null`
+    git_status=`git rev-parse 2> /dev/null`
     if [ "$?" -eq 128 ] ; then
         git=""
     else


### PR DESCRIPTION
Improve prompt performance by changing git commands.  I made a compromise and removed the asterisk for dirty branches.  It became very slow when working in large git repos.
